### PR TITLE
Avoid @ in the lcd_WaitVRAM macro

### DIFF
--- a/rgbds-hello-world/src/memory.asm
+++ b/rgbds-hello-world/src/memory.asm
@@ -5,9 +5,9 @@ INCLUDE "gbhw.inc"
 ; Macro that pauses until VRAM available.
 
 lcd_WaitVRAM: MACRO
-        ld      a,[rSTAT]       ; <---+
+.loop\@ ld      a,[rSTAT]       ; <---+
         and     STATF_BUSY      ;     |
-        jr      nz,@-4          ; ----+
+        jr      nz, .loop\@     ; ----+
         ENDM
 
         PUSHS           ; Push the current section onto assember stack.


### PR DESCRIPTION
The @ label is broken in the current release of rgbds. Instead, uses a
local \@ label to jump to the beginning of the loop. This is also more
robust as it does not assume the size in bytes of the instructions.

Further info: https://github.com/rednex/rgbds/issues/273