### PR TITLE
Added manufacturer: word

### DIFF
--- a/dmgforth.fs
+++ b/dmgforth.fs
@@ -55,10 +55,13 @@ variable rom-offset-variable
   dup #4 > abort" Manufacturer Code is too long"
   $013F offset>addr swap move ;
 
-: gbgame $00 $0143 rom! ; ( non color )
-: cgbgame $c0 $0143 rom! ; ( Game works on CGB only )
-: (c)gbgame $80 $0143 rom! ; ( Game supports CGB functions, but works on old gameboys also )
+: licensee:
+  parse-line
+  dup #2 > abort" Licensee Code is too long"
+  $0144 offset>addr swap move
+  $33 $014B rom!;
 
+: gbgame $00 $0143 rom! ; ( non color )
 
 : nop $0 rom, ;
 

--- a/dmgforth.fs
+++ b/dmgforth.fs
@@ -50,6 +50,11 @@ variable rom-offset-variable
   dup #15 > abort" Title is too long"
   $134 offset>addr swap move ;
 
+: manufacturer:
+  parse-line
+  dup #4 > abort" Manufacturer Code is too long"
+  $013F offset>addr swap move ;
+
 : gbgame $00 rom, ; ( non color )
 
 : nop $0 rom, ;

--- a/dmgforth.fs
+++ b/dmgforth.fs
@@ -55,7 +55,7 @@ variable rom-offset-variable
   dup #4 > abort" Manufacturer Code is too long"
   $013F offset>addr swap move ;
 
-: gbgame $00 rom, ; ( non color )
+: gbgame $00 $0143 rom! ; ( non color )
 
 : nop $0 rom, ;
 

--- a/dmgforth.fs
+++ b/dmgforth.fs
@@ -56,6 +56,9 @@ variable rom-offset-variable
   $013F offset>addr swap move ;
 
 : gbgame $00 $0143 rom! ; ( non color )
+: cgbgame $c0 $0143 rom! ; ( Game works on CGB only )
+: (c)gbgame $80 $0143 rom! ; ( Game supports CGB functions, but works on old gameboys also )
+
 
 : nop $0 rom, ;
 

--- a/rom.fs
+++ b/rom.fs
@@ -61,7 +61,7 @@ jmp forward
 $0104 ==> ( nintendo logo )
 logo
 title: EXAMPLE
-gbgame
+$143 ==> gbgame
 
 $144 ==>
 $00 rom, $00 rom, ( licensee code )

--- a/rom.fs
+++ b/rom.fs
@@ -61,8 +61,9 @@ jmp forward
 $0104 ==> ( nintendo logo )
 logo
 title: EXAMPLE
-$143 ==> gbgame
+gbgame
 
+$144 ==>
 $00 rom, $00 rom, ( licensee code )
 $00 rom,          ( gb 00 or super gameboy 03 )
 $00 rom,          ( cartridge type - rom only )


### PR DESCRIPTION
Added a word similar to `title:` to set the manufacturer code (4 chars). Purpose seems to be a bit unclear but it's probably nice to have _the toolkit_ feature complete.

Also added the address to the `gbgame` word so that the order does not matter.

Experimented a bit with the other 2 values for this field (cgb supported / cgb only) but more of a draft still.