### PR TITLE
Make ~e alias of ~n

### DIFF
--- a/src/asm.fs
+++ b/src/asm.fs
@@ -168,6 +168,7 @@ end-types
 : ~(nn) ~(n) ~(nn)_ | ;
 : ~nn ~n ~nn_ | ;
 : ~qq|dd ~dd ~qq | ;
+: ~e ~n ;
 
 : operand ( value type )
   create , , does> 2@ push-arg ;
@@ -388,7 +389,7 @@ instruction jp,
 end-instruction
 
 instruction jr,
-  ~nn ~~> %00 %011 %000 op, e, ::
+  ~e ~~> %00 %011 %000 op, e, ::
 end-instruction
 
 instruction ld,


### PR DESCRIPTION
Not sure if it makes sense to have an alias for it (since it would still be an immediate value), but I figured it makes the pattern matching / emitting more symmetrical.

If not a good idea, `jr,` should probably still match on `~n` specifically rather than `~nn` (because `e,` would discard the higher part of the byte anyway).