### PR TITLE
Finish decoding StopLCD

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-SHELL := /bin/bash
+nSHELL := /bin/bash
 
 .PHONY: build build-org buildall test watch
 
@@ -11,6 +11,9 @@ output.gb:
 build: output.gb
 buildall: build-org build
 
+check:
+	gforth src/asm.spec.fs -e bye
+
 test:
 	@$(MAKE) build
 	@colordiff -U 2 <(hexdump -v rgbds-hello-world/hello-world.gb) <(hexdump -v output.gb)
@@ -19,3 +22,4 @@ test:
 
 watch:
 	watch --color $(MAKE) test
+

--- a/game.fs
+++ b/game.fs
@@ -164,8 +164,9 @@ label .wait
 .wait #NZ jr,
 [rLCDC] A ld,
 A #7 # res,
+A [rLCDC] ld,
 
-$e0 rom, $40 rom, $c9 rom, 
+$c9 rom, 
 
 require ./src/fonts.fs
 

--- a/game.fs
+++ b/game.fs
@@ -163,9 +163,9 @@ label .wait
 #145 # cp,
 .wait #NZ jr,
 [rLCDC] A ld,
+A #7 # res,
 
-
-$cb rom, $bf rom, $e0 rom, $40 rom, $c9 rom, 
+$e0 rom, $40 rom, $c9 rom, 
 
 require ./src/fonts.fs
 

--- a/game.fs
+++ b/game.fs
@@ -158,9 +158,14 @@ rlca,
 
 #NC ret,
 
-                                    $f0 rom,
-$44 rom, $fe rom, $91 rom, $20 rom, $fa rom, $f0 rom, $40 rom, $cb rom, $bf rom, $e0 rom, $40 rom, $c9 rom, 
+label .wait
+[rLY] A ld,
+#145 # cp,
+.wait #NZ jr,
+[rLCDC] A ld,
 
+
+$cb rom, $bf rom, $e0 rom, $40 rom, $c9 rom, 
 
 require ./src/fonts.fs
 

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -407,7 +407,8 @@ end-instruction
 %00 %000 %000 simple-instruction nop,
 
 instruction ret,
-        ~cc ~~> %11 0cc %000 op, ::
+        ~cc ~~> %11  0cc %000 op, ::
+            ~~> %11 %001 %001 op, ::
 end-instruction
 
 %00 %000 %111 simple-instruction rlca,

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -154,6 +154,7 @@ begin-types
   type ~r
   type ~dd
   type ~qq
+  type ~b
   type ~n/8
   type ~n/16
   type ~(n/8)
@@ -192,10 +193,14 @@ end-types
 
 ( Push an immediate value to the arguments stack )
 : #
-  dup $FF <= if
-    ~n/8 ~n/16 | push-arg
+  dup %111 <= if
+    ~b ~n/8 | ~n/16 | push-arg
   else
-    ~n/16 push-arg
+    dup $FF <= if
+      ~n/8 ~n/16 | push-arg
+    else
+      ~n/16 push-arg
+    then
   then ;
 
 : ]*
@@ -311,7 +316,7 @@ end-types
 ALSO GB-ASSEMBLER-EMITERS
 DEFINITIONS
 
-: n' arg2-value ;
+: b' arg2-value ;
 : r  arg1-value ;
 : r' arg2-value ;
 : dd0' arg2-value 1 lshift ;
@@ -432,8 +437,8 @@ instruction res,
 \ Actually takes r and b, where b is an immediate value in the range
 \ 0-7 (i.e. a byte). Simply using # and defined n (same as r) for
 \ now, there might be room for improvement.
-  ~r ~n   ~~>  %11 %001 %011 op,
-               %10   n'    r op, ::
+  ~r ~b   ~~>  %11 %001 %011 op,
+               %10   b'    r op, ::
 end-instruction
 
 ( Prevent the halt bug by emitting a NOP right after halt )

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -423,6 +423,9 @@ instruction stop,
 end-instruction
 
 instruction res,
+\ Actually takes b and r, where b is an immediate value in the range
+\ 0-7 (i.e. a byte). Simply using # and defined n (same as r) for
+\ now, there might be room for improvement.
   ~r ~n   ~~>  %11 %001 %011 op,
                %10    n   r' op, ::
 end-instruction

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -314,6 +314,7 @@ end-types
 ALSO GB-ASSEMBLER-EMITERS
 DEFINITIONS
 
+: n  arg1-value ;
 : r  arg1-value ;
 : r' arg2-value ;
 : dd0' arg2-value 1 lshift ;
@@ -418,6 +419,11 @@ end-instruction
 instruction stop,
   ~~> %00 %010 %000 op,
       %00 %000 %000 op, ::
+end-instruction
+
+instruction res,
+  ~r ~n   ~~>  %11 %001 %011 op,
+               %10    n   r' op, ::
 end-instruction
 
 ( Prevent the halt bug by emitting a NOP right after halt )

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -319,6 +319,7 @@ DEFINITIONS
 : dd0' arg2-value 1 lshift ;
 : 0cc  arg1-value ;
 : 0cc' arg2-value ;
+: 1cc' 0cc' %100 + ;
 
 :  8lit, $ff and emit ;
 : 16lit,
@@ -389,7 +390,8 @@ instruction jp,
 end-instruction
 
 instruction jr,
-  ~e ~~> %00 %011 %000 op, e, ::
+  ~e     ~~> %00 %011 %000 op, e, ::
+  ~e ~cc ~~> %00 1cc' %000 op, e, ::
 end-instruction
 
 instruction ld,
@@ -408,6 +410,10 @@ instruction ret,
 end-instruction
 
 %00 %000 %111 simple-instruction rlca,
+
+instruction cp,
+  ~n ~~> %11 %111 %110 op, n, ::
+end-instruction
 
 instruction stop,
   ~~> %00 %010 %000 op,

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -154,10 +154,10 @@ begin-types
   type ~r
   type ~dd
   type ~qq
-  type ~n
-  type ~nn_
-  type ~(n)
-  type ~(nn)_
+  type ~n/8
+  type ~n/16
+  type ~(n/8)
+  type ~(n/16)
   type ~A
   type ~cc
   type ~unresolved-reference
@@ -165,10 +165,7 @@ end-types
 
 : | or ;
 
-: ~(nn) ~(n) ~(nn)_ | ;
-: ~nn ~n ~nn_ | ;
 : ~qq|dd ~dd ~qq | ;
-: ~e ~n ;
 
 : operand ( value type )
   create , , does> 2@ push-arg ;
@@ -196,16 +193,16 @@ end-types
 ( Push an immediate value to the arguments stack )
 : #
   dup $FF <= if
-    ~n push-arg
+    ~n/8 ~n/16 | push-arg
   else
-    ~nn push-arg
+    ~n/16 push-arg
   then ;
 
 : ]*
   dup $FF00 >= if
-    ~(n) push-arg
+    ~(n/8) ~(n/16) | push-arg
   else
-    ~(nn) push-arg
+    ~(n/16) push-arg
   then ;
 
 
@@ -214,20 +211,20 @@ end-types
 : presume
   create
   here
-  0 , ~unresolved-reference ~nn | ,
+  0 , ~unresolved-reference ~n/16 | ,
   create-empty-reflist swap !
   does> dup cell+ @ push-arg ;
 
 : redefine-label-forward ( xt -- )
   >body
   offset over !
-  ~nn swap cell+ ! ;
+  ~n/16 swap cell+ ! ;
 
 : resolve-label-references ( xt -- )
   offset swap >body @ reflist-resolve ;
 
 : fresh-label
-  create offset , does> @ ~nn push-arg ;
+  create offset , does> @ ~n/16 push-arg ;
 
 : label
   parse-name
@@ -370,7 +367,16 @@ PREVIOUS DEFINITIONS
   ` ~~> r> ` literal  ` emit ` ::
   ` end-instruction ;
 
+
 ( INSTRUCTIONS )
+
+( Argument patterns )
+: ~n ~n/8 ;
+: ~e ~n/16 ;
+: ~nn ~n/8 ~n/16 | ;
+: ~(n) ~(n/8) ;
+: ~(nn) ~(n/8) ~(n/16) | ;
+
 
 instruction call,
   ~nn      ~~> %11 %001 %101 op, nn, ::

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -311,7 +311,7 @@ end-types
 ALSO GB-ASSEMBLER-EMITERS
 DEFINITIONS
 
-: n  arg1-value ;
+: n' arg2-value ;
 : r  arg1-value ;
 : r' arg2-value ;
 : dd0' arg2-value 1 lshift ;
@@ -429,11 +429,11 @@ instruction stop,
 end-instruction
 
 instruction res,
-\ Actually takes b and r, where b is an immediate value in the range
+\ Actually takes r and b, where b is an immediate value in the range
 \ 0-7 (i.e. a byte). Simply using # and defined n (same as r) for
 \ now, there might be room for improvement.
   ~r ~n   ~~>  %11 %001 %011 op,
-               %10    n   r' op, ::
+               %10   n'    r op, ::
 end-instruction
 
 ( Prevent the halt bug by emitting a NOP right after halt )

--- a/src/asm.spec.fs
+++ b/src/asm.spec.fs
@@ -1,0 +1,12 @@
+require ./asm.fs
+
+also gb-assembler
+
+:noname
+  assert( ~r  ~r    type-match )
+  assert( ~n  ~n/8  type-match )
+  assert( ~n  ~n/16 type-match invert )
+  assert( ~nn ~n/8  type-match )
+  assert( ~nn ~n/16 type-match )
+  ." Test passed" ;
+execute

--- a/src/gbhw.fs
+++ b/src/gbhw.fs
@@ -8,6 +8,8 @@ also gb-assembler
 
 : [rLCDC] $FF40 ]* ;
 
+: [rLY]   $FF44 ]* ;
+
 
 %00000000 constant LCDCF_OFF        ( LCD Control Operation)
 %10000000 constant LCDCF_ON         ( LCD Control Operation)


### PR DESCRIPTION
`res,` actually takes `b` and `r`, where `b` is an immediate value in the range 0-7 (i.e. a byte).
Simply using `#` and defined `n` (same as `r`) for now in ff16f86, but there might be room for improvement.