### PR TITLE
Include games in a sealed vocabulary

### DIFF
--- a/dmgforth
+++ b/dmgforth
@@ -53,13 +53,12 @@ require ./src/user.fs
 )
 :noname
   get-order
-  get-current
-  also dmgforth-user definitions
-  seal
-
+  
+  [user-definitions]
+  seal also
   input-file included 
+  [end-user-definitions]
 
-  set-current 
   set-order
 ; execute
 

--- a/dmgforth
+++ b/dmgforth
@@ -2,6 +2,8 @@
 \                                           -*- forth -*-
 
 vocabulary dmgforth
+vocabulary dmgforth-user
+
 get-current
 also dmgforth definitions
 constant previous-wid
@@ -37,9 +39,29 @@ argc @ 3 <> [if]
   ' usage stderr outfile-execute
 [then]
 
-next-arg included
-
+next-arg 2constant input-file
 next-arg 2constant output-file
+
+require ./src/user.fs
+
+( We want to load the input file sealed in the DMGFORTH-USER
+( vocabulary. The problem is that we do not want to populate this
+  vocabulary with auxiliary words to load the input-file.
+
+  Instead, we put all the words in this colon-definition to resolve
+  the word into addresses before we seal and load the game.
+)
+:noname
+  get-order
+  get-current
+  also dmgforth-user definitions
+  seal
+
+  input-file included 
+
+  set-current 
+  set-order
+; execute
 
 depth 0<> [if]
   ." The stac2k is not empty!" cr

--- a/dmgforth
+++ b/dmgforth
@@ -13,7 +13,7 @@ also dmgforth
 require ./src/rom.fs
 require ./src/asm.fs
 
-also gb-assembler
+also gb-assembler-impl
 ' rom, IS emit
 ' rom-offset IS offset
 ' rom! IS emit-to

--- a/etc/dmgforth.el
+++ b/etc/dmgforth.el
@@ -20,7 +20,7 @@
 (require 'forth-mode)
 
 (defvar dmgforth-defining-words
-  '("simple-instruction" "instruction" "label" "presume"))
+  '("simple-instruction" "instruction" "label" "presume" "export"))
 
 (dolist (w dmgforth-defining-words)
   (forth-syntax--define w #'forth-syntax--state-defining-word))

--- a/examples/hello-world/hello.fs
+++ b/examples/hello-world/hello.fs
@@ -31,16 +31,18 @@ presume TileData
 
 TileData hl ld,
 _VRAM # de ld,
-256 8 * # bc ld,
+[host] 256 8 * [endhost] # bc ld,
 
 mem_CopyMono call,
 
-LCDCF_ON
-LCDCF_BG8000 or
-LCDCF_BG9800 or
-LCDCF_BGON or
-LCDCF_OBJ16 or
-LCDCF_OBJOFF or # a ld,
+[host]
+  LCDCF_ON
+  LCDCF_BG8000 or
+  LCDCF_BG9800 or
+  LCDCF_BGON or
+  LCDCF_OBJ16 or
+  LCDCF_OBJOFF or
+[endhost] # a ld,
 
 a [rLCDC] ld,
 
@@ -48,17 +50,20 @@ a [rLCDC] ld,
 
 _SCRN0 # hl ld,
 
-SCRN_VX_B SCRN_VY_B * # bc ld,
+[host] SCRN_VX_B SCRN_VY_B * [endhost] # bc ld,
 
 mem_SetVRAM call,
 
+[host]
 : %Title s" Hello World !" ;
+[endhost]
+
 PRESUME Title
 
 Title hl ld,
-_SCRN0 3 + SCRN_VY_B 7 * + # de ld,
+[host] _SCRN0 3 + SCRN_VY_B 7 * + [endhost] # de ld,
 
-%Title nip # bc ld,
+[host] %Title nip [endhost] # bc ld,
 
 mem_CopyVRAM call,
 
@@ -67,9 +72,13 @@ halt,
 nop,
 wait jr,
 
+( HACK: Don't use dmgforth internals here )
 label Title
+[host]
+also dmgforth
 %title rom-move
-
+previous
+[endhost]
 
 nop,
 

--- a/examples/hello-world/hello.fs
+++ b/examples/hello-world/hello.fs
@@ -1,5 +1,4 @@
-require ../../src/asm.fs
-require ../../src/gbhw.fs
+require gbhw.fs
 
 also gb-assembler
 

--- a/lib/gbhw.fs
+++ b/lib/gbhw.fs
@@ -1,4 +1,3 @@
-require ./asm.fs
 also gb-assembler
 
 ( Special registers! )

--- a/lib/ibm-font.fs
+++ b/lib/ibm-font.fs
@@ -1,12 +1,7 @@
 ( IBMPC1 8x8 Character Set Macros V1.2 )
 
-vocabulary fonts
-
-get-current
-also fonts definitions
-constant previous-wid
-
-: discard-line 10 parse 2drop ;
+[host]
+also dmgforth
 
 : >
   parse-name
@@ -20,9 +15,11 @@ constant previous-wid
       true abort" Wrong character!"
     endcase
   loop 
-  nip 
+  nip
   rom, ;
 
+previous
+[endhost]
 
 > .XXXXXX.  \ Use to be a space ?????
 > .X....X.
@@ -2329,6 +2326,3 @@ constant previous-wid
 > ........
 > ........
 > ........
-
-previous-wid set-current
-previous

--- a/lib/memory.fs
+++ b/lib/memory.fs
@@ -1,3 +1,5 @@
+also gb-assembler
+
 ( these are written to the memory reserved for high-to-low of p10-p13 interrupt start addresses )
 (
 ;***************************************************************************
@@ -79,12 +81,17 @@ label .skip
     ret,
 end-local
 
+[host]
+also gb-assembler
+
 : lcd_WaitVRAM
   here<
     [rSTAT] a ld,
     STATF_BUSY # and,
   <there #nz jr, ;
 
+previous
+[endhost]
 
 (
 ;***************************************************************************
@@ -152,3 +159,5 @@ label .skip
   .loop #nz jr,
   ret,
 end-local
+
+previous

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -9,14 +9,23 @@ bits of the words are used to tag the values with type information. )
 
 require ./utils.fs
 
-[IFUNDEF] gb-assembler
+[IFUNDEF] gb-assembler-impl
 vocabulary gb-assembler
+vocabulary gb-assembler-impl
 vocabulary gb-assembler-emiters
 [ENDIF]
 
 get-current
-also gb-assembler definitions
+also gb-assembler-impl definitions
 constant previous-wid
+
+: [public]
+  get-current
+  also gb-assembler definitions ;
+
+: [endpublic]
+  previous set-current ;
+
 
 ( You can override this vectored words in order to customize where the
 ( assembler will write its output )
@@ -174,6 +183,8 @@ end-types
 : operand ( value type )
   create , , does> 2@ push-arg ;
 
+[public]
+
 ( Define register operands )
 %111 ~r ~A | operand A
 %000 ~r      operand B
@@ -197,7 +208,6 @@ end-types
 %0 ~[DE]  operand [DE]
 %0 ~[HL+] operand [HL+]
 
-
 ( Push an immediate value to the arguments stack )
 : #
   dup %111 <= if
@@ -218,9 +228,15 @@ end-types
   then ;
 
 
+[endpublic]
+
+
+
 ( LABEL & REFERENCES )
 
-: here< rom-offset ;
+[public]
+
+: here< offset ;
 : <there # ;
 
 : presume
@@ -229,6 +245,9 @@ end-types
   0 , ~unresolved-reference ~n/16 | ,
   create-empty-reflist swap !
   does> dup cell+ @ push-arg ;
+
+[endpublic]
+
 
 : redefine-label-forward ( xt -- )
   >body
@@ -241,6 +260,7 @@ end-types
 : fresh-label
   create offset , does> @ ~n/16 push-arg ;
 
+[public]
 : label
   parse-name
   2dup find-name ?dup if
@@ -251,8 +271,10 @@ end-types
   else
     nextname fresh-label
   then ;
+[endpublic]
 
 
+[public]
 ( Utility words to define local labels )
 : local ( -- wid )
   get-current
@@ -263,6 +285,8 @@ end-types
 : end-local
   previous
   set-current immediate ;
+
+[endpublic]
 
 
 ( Arguments pattern matching )
@@ -408,6 +432,8 @@ PREVIOUS DEFINITIONS
 : ~(nn) ~(n/16) | ;
 
 
+[public]
+
 instruction and,
   ~n ~~> %11 %100 %110 op, n, ::
 end-instruction
@@ -496,6 +522,7 @@ end-instruction
 ( Prevent the halt bug by emitting a NOP right after halt )
 : halt, halt%, nop, ;
 
+[endpublic]
 
 previous-wid set-current
 previous

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -23,7 +23,13 @@ $60 ==> reti,
 
 $100 ==> ( start entry point )
 
+get-order
+get-current 
+also dmgforth-user definitions
 presume main
+set-current
+' main alias main
+set-order
 
 nop,
 main jp,

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -1,4 +1,6 @@
 require ./asm.fs
+require ./user.fs
+
 also gb-assembler
 
 ( Cartridge structure )
@@ -23,13 +25,11 @@ $60 ==> reti,
 
 $100 ==> ( start entry point )
 
-get-order
-get-current 
-also dmgforth-user definitions
 presume main
-set-current
+
+[user-definitions]
 ' main alias main
-set-order
+[end-user-definitions]
 
 nop,
 main jp,

--- a/src/gbhw.fs
+++ b/src/gbhw.fs
@@ -2,6 +2,7 @@ require ./asm.fs
 also gb-assembler
 
 ( Special registers! )
+[host]
 : [rGBP]  $FF47 ]* ;
 : [rSCY]  $FF42 ]* ;
 : [rSCX]  $FF43 ]* ;
@@ -10,6 +11,7 @@ also gb-assembler
 
 : [rLY]   $FF44 ]* ;
 : [rSTAT] $FF41 ]* ;
+[endhost]
 
 %00000000 constant LCDCF_OFF        ( LCD Control Operation)
 %10000000 constant LCDCF_ON         ( LCD Control Operation)

--- a/src/user.fs
+++ b/src/user.fs
@@ -4,9 +4,15 @@
   parse-name 
   2dup find-name name>int >r
   nextname r> alias ;
+
+: [user-definitions]
+  get-current
+  also dmgforth-user definitions ;
   
-get-current
-also dmgforth-user definitions
+: [end-user-definitions]
+  previous set-current ;
+
+[user-definitions]
 also dmgforth
 
 : [host] also forth ;
@@ -25,5 +31,4 @@ export previous
 export require
 
 previous
-previous
-set-current
+[end-user-definitions]

--- a/src/user.fs
+++ b/src/user.fs
@@ -1,0 +1,29 @@
+( User Vocabulary )
+
+: export
+  parse-name 
+  2dup find-name name>int >r
+  nextname r> alias ;
+  
+get-current
+also dmgforth-user definitions
+also dmgforth
+
+: [host] also forth ;
+: [endhost] previous ;
+
+: c, rom, ;
+
+export ( 
+export ==>
+export \
+export also
+export constant
+export gb-assembler
+export include
+export previous
+export require
+
+previous
+previous
+set-current


### PR DESCRIPTION
Games are included with only the dmgforth-user vocabulary active. This vocabulary control which words games can use.

The words `[host]` and `[endhost]` allow the user to escape this seal and have full access to the forth vocabulary (*not the dmgforth one directly!*).

Also, restrict the words exposed in the `gb-assembler` vocabulary.