### PR TITLE
Refactor cartridge

### DIFF
--- a/dmgforth
+++ b/dmgforth
@@ -53,10 +53,10 @@ require ./src/user.fs
 )
 :noname
   get-order
-  
+
   [user-definitions]
   seal also
-  input-file included 
+  input-file included
   [end-user-definitions]
 
   set-order
@@ -67,5 +67,6 @@ depth 0<> [if]
 [endif]
 
 fix-header-complement
+fix-global-checksum
 output-file dump-rom
 bye

--- a/examples/hello-world/hello.fs
+++ b/examples/hello-world/hello.fs
@@ -2,6 +2,8 @@ require gbhw.fs
 
 also gb-assembler
 
+title: EXAMPLE
+
 $40 ==> reti,
 $48 ==> reti,
 $50 ==> reti,

--- a/examples/hello-world/hello.fs
+++ b/examples/hello-world/hello.fs
@@ -2,7 +2,12 @@ require gbhw.fs
 
 also gb-assembler
 
-$61 ==> 
+$40 ==> reti,
+$48 ==> reti,
+$50 ==> reti,
+$58 ==> reti,
+$60 ==> reti,
+$61 ==>
 include memory.fs
 
 $150 ==>

--- a/lib/gbhw.fs
+++ b/lib/gbhw.fs
@@ -305,49 +305,6 @@ $FF30 constant _AUD3WAVERAM  ( $FF30->$FF3F )
 
 (
   *************************
-  Cart related
-  *************************
-)
-
-#0 constant ROM_NOMBC
-#1 constant ROM_MBC1
-#2 constant ROM_MBC1_RAM
-#3 constant ROM_MBC1_RAM_BAT
-#5 constant ROM_MBC2
-#6 constant ROM_MBC2_BAT
-#8 constant ROM_NOMBC_RAM
-#9 constant ROM_NOMBC_RAM_BAT
-
-#0 constant ROM_SIZE_256KBIT
-#1 constant ROM_SIZE_512KBIT
-#2 constant ROM_SIZE_1M
-#3 constant ROM_SIZE_2M
-#4 constant ROM_SIZE_4M
-#5 constant ROM_SIZE_8M
-#6 constant ROM_SIZE_16M
-
-#0 constant ROM_SIZE_32KBYTE
-#1 constant ROM_SIZE_64KBYTE
-#2 constant ROM_SIZE_128KBYTE
-#3 constant ROM_SIZE_256KBYTE
-#4 constant ROM_SIZE_512KBYTE
-#5 constant ROM_SIZE_1MBYTE
-#6 constant ROM_SIZE_2MBYTE
-
-#0 constant RAM_SIZE_0KBIT
-#1 constant RAM_SIZE_16KBIT
-#2 constant RAM_SIZE_64KBIT
-#3 constant RAM_SIZE_256KBIT
-#4 constant RAM_SIZE_1MBIT
-
-#0 constant RAM_SIZE_0KBYTE
-#1 constant RAM_SIZE_2KBYTE
-#2 constant RAM_SIZE_8KBYTE
-#3 constant RAM_SIZE_32KBYTE
-#4 constant RAM_SIZE_128KBYTE
-
-(
-  *************************
   Keypad related
   *************************
 )

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -106,6 +106,21 @@ $33 constant USE_NEW_LICENCE_CODE
 : fix-header-complement
   header-complement $014D rom! ;
 
+: global-checksum
+  0
+  $014E $0 ?do
+    i rom@ +
+  loop
+  rom-size $0150 ?do
+    i rom@ +
+  loop
+  $FFFF and ;
+
+: fix-global-checksum
+  global-checksum dup
+  higher-byte $014E rom!
+  lower-byte $014F rom! ;
+
 ( Cartridge structure )
 
 ( A placeholder for values)
@@ -154,7 +169,7 @@ $014A ==> $01 rom,                  ( market code jp/int )
 $014B ==> USE_NEW_LICENCE_CODE rom, ( old licensee code )
 $014C ==> $00 rom,                  ( mask rom version number )
 $014D ==> $xx rom,                  ( complement checksum )
-$014E ==> $f8 rom, $9c rom,         ( global checksum )
+$014E ==> $xx rom, $xx rom,         ( global checksum )
 
 ( header end )
 

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -5,6 +5,14 @@ also gb-assembler
 
 ( Constants used in cartridge header )
 
+( CGB flag [$0143] )
+$80 constant CGB_SUPPORTED
+$C0 constant CGB_ONLY
+
+( SGB flag [$0146] )
+$00 constant SGB_DISABLED
+$03 constant SGB_ENABLED
+
 ( Cartridge type [$0147] )
 $00 constant ROM_NOMBC
 $01 constant ROM_MBC1

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -3,27 +3,27 @@ require ./user.fs
 
 also gb-assembler
 
-( Cartridge structure )
-
-$00 ==>         ( restart $00 address )
-$08 ==>         ( restart $08 address )
-$10 ==>         ( restart $10 address )
-$18 ==>         ( restart $18 address )
-$20 ==>         ( restart $20 address )
-$28 ==>         ( restart $28 address )
-$30 ==>         ( restart $30 address )
-$38 ==>         ( restart $38 address )
-$40 ==> reti,   ( vertical blank interrupt start address )
-$48 ==> reti,   ( timer overflowInterrupt start address )
-$50 ==> reti,   ( LCDC status interrupt start address )
-$58 ==> reti,   ( serial transfer completion interrupt start address  )
-$60 ==> reti,   ( high-to-low of p10 interrupt start address )
-$68 ==>         ( high-to-low of p11 interrupt start address )
-$70 ==>         ( high-to-low of p12 interrupt start address )
-$78 ==>         ( high-to-low of p13 interrupt start address )
-
 ( A placeholder for values)
 : $xx $42 ;
+
+( Cartridge structure )
+
+$00 ==> ( restart $00 address )
+$08 ==> ( restart $08 address )
+$10 ==> ( restart $10 address )
+$18 ==> ( restart $18 address )
+$20 ==> ( restart $20 address )
+$28 ==> ( restart $28 address )
+$30 ==> ( restart $30 address )
+$38 ==> ( restart $38 address )
+$40 ==> ( vertical blank interrupt start address )
+$48 ==> ( timer overflowInterrupt start address )
+$50 ==> ( LCDC status interrupt start address )
+$58 ==> ( serial transfer completion interrupt start address  )
+$60 ==> ( high-to-low of p10 interrupt start address )
+$68 ==> ( high-to-low of p11 interrupt start address )
+$70 ==> ( high-to-low of p12 interrupt start address )
+$78 ==> ( high-to-low of p13 interrupt start address )
 
 $100 ==> ( start entry point )
 

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -149,6 +149,7 @@ presume main
 
 [user-definitions]
 ' main alias main
+' title: alias title:
 [end-user-definitions]
 
 nop,
@@ -157,9 +158,7 @@ main jp,
 ( start header )
 
 $0104 ==> nintendo-logo,
-title: EXAMPLE
-$0143 ==> CGB_DISABLED rom,
-
+$0143 ==> CGB_DISABLED rom,         ( color GB function support )
 $0144 ==> $00 rom, $00 rom,         ( new licensee code )
 $0146 ==> $00 rom,                  ( gb 00 or super gameboy 03 )
 $0147 ==> $00 rom,                  ( cartridge type - rom only )

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -143,9 +143,6 @@ $33 constant USE_NEW_LICENCE_CODE
 
 ( Cartridge structure )
 
-( A placeholder for values)
-: $xx $42 ;
-
 $00 ==> ( restart $00 address )
 $08 ==> ( restart $08 address )
 $10 ==> ( restart $10 address )
@@ -163,7 +160,7 @@ $68 ==> ( high-to-low of p11 interrupt start address )
 $70 ==> ( high-to-low of p12 interrupt start address )
 $78 ==> ( high-to-low of p13 interrupt start address )
 
-$100 ==> ( start entry point [$100-$103] )
+$100 ==> ( start entry point [$0100-$0103] )
 
 presume main
 
@@ -175,21 +172,23 @@ presume main
 nop,
 main jp,
 
-( start header )
+( start header [$0100-$014F] )
 
 $0104 ==> nintendo-logo,
+$0134 ==>                           ( title )
+$013F ==>                           ( manufacturer code )
 $0143 ==> CGB_DISABLED rom,         ( color GB function support )
-$0144 ==> $00 rom, $00 rom,         ( new licensee code )
-$0146 ==> $00 rom,                  ( gb 00 or super gameboy 03 )
-$0147 ==> $00 rom,                  ( cartridge type - rom only )
-$0148 ==> $00 rom,                  ( rom size )
-$0149 ==> $00 rom,                  ( ram size )
-$014A ==> $01 rom,                  ( market code jp/int )
+$0144 ==>                           ( new licensee code )
+$0146 ==> SGB_DISABLED rom,         ( gb 00 or super gameboy 03 )
+$0147 ==> ROM_NOMBC rom,            ( cartridge type - rom only )
+$0148 ==> ROM_SIZE_32KBYTE rom,     ( rom size )
+$0149 ==> RAM_SIZE_NONE rom,        ( ram size )
+$014A ==> DEST_INT rom,             ( market code jp/int )
 $014B ==> USE_NEW_LICENCE_CODE rom, ( old licensee code )
 $014C ==> $00 rom,                  ( mask rom version number )
-$014D ==> $xx rom,                  ( complement checksum )
-$014E ==> $xx rom, $xx rom,         ( global checksum )
+$014D ==>                           ( complement checksum )
+$014E ==>                           ( global checksum )
 
-( header end )
+( header end [$0150...] )
 
 previous

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -3,6 +3,45 @@ require ./user.fs
 
 also gb-assembler
 
+( Constants used in cartridge header )
+
+#0 constant ROM_NOMBC
+#1 constant ROM_MBC1
+#2 constant ROM_MBC1_RAM
+#3 constant ROM_MBC1_RAM_BAT
+#5 constant ROM_MBC2
+#6 constant ROM_MBC2_BAT
+#8 constant ROM_NOMBC_RAM
+#9 constant ROM_NOMBC_RAM_BAT
+
+#0 constant ROM_SIZE_256KBIT
+#1 constant ROM_SIZE_512KBIT
+#2 constant ROM_SIZE_1M
+#3 constant ROM_SIZE_2M
+#4 constant ROM_SIZE_4M
+#5 constant ROM_SIZE_8M
+#6 constant ROM_SIZE_16M
+
+#0 constant ROM_SIZE_32KBYTE
+#1 constant ROM_SIZE_64KBYTE
+#2 constant ROM_SIZE_128KBYTE
+#3 constant ROM_SIZE_256KBYTE
+#4 constant ROM_SIZE_512KBYTE
+#5 constant ROM_SIZE_1MBYTE
+#6 constant ROM_SIZE_2MBYTE
+
+#0 constant RAM_SIZE_0KBIT
+#1 constant RAM_SIZE_16KBIT
+#2 constant RAM_SIZE_64KBIT
+#3 constant RAM_SIZE_256KBIT
+#4 constant RAM_SIZE_1MBIT
+
+#0 constant RAM_SIZE_0KBYTE
+#1 constant RAM_SIZE_2KBYTE
+#2 constant RAM_SIZE_8KBYTE
+#3 constant RAM_SIZE_32KBYTE
+#4 constant RAM_SIZE_128KBYTE
+
 ( A placeholder for values)
 : $xx $42 ;
 

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -23,6 +23,27 @@ $05 constant ROM_MBC2
 $06 constant ROM_MBC2_BAT
 $08 constant ROM_NOMBC_RAM
 $09 constant ROM_NOMBC_RAM_BAT
+$0B constant ROM_MMM01
+$0C constant ROM_MMM01_RAM
+$0D constant ROM_MMM01_RAM_BAT
+$0F constant ROM_MBC3_TIMER_BAT
+$10 constant ROM_MBC3_TIMER_RAM_BAT
+$11 constant ROM_MBC3
+$12 constant ROM_MBC3_RAM
+$13 constant ROM_MBC3_RAM_BAT
+$15 constant ROM_MBC4
+$16 constant ROM_MBC4_RAM
+$17 constant ROM_MBC4_RAM_BAT
+$19 constant ROM_MBC5
+$1A constant ROM_MBC5_RAM
+$1B constant ROM_MBC5_RAM_BAT
+$1C constant ROM_MBC5_RUMBLE
+$1D constant ROM_MBC5_RUMBLE_RAM
+$1E constant ROM_MBC5_RUMBLE_RAM_BAT
+$FC constant ROM_POCKET_CAMEREA
+$FD constant ROM_BANDAI_TAMA5
+$FE constant ROM_HUC3
+$FF constant ROM_HUC1_RAM_BAT
 
 \ #0 constant ROM_SIZE_256KBIT
 \ #1 constant ROM_SIZE_512KBIT

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -44,38 +44,40 @@ $FD constant ROM_BANDAI_TAMA5
 $FE constant ROM_HUC3
 $FF constant ROM_HUC1_RAM_BAT
 
-\ #0 constant ROM_SIZE_256KBIT
-\ #1 constant ROM_SIZE_512KBIT
-\ #2 constant ROM_SIZE_1M
-\ #3 constant ROM_SIZE_2M
-\ #4 constant ROM_SIZE_4M
-\ #5 constant ROM_SIZE_8M
-\ #6 constant ROM_SIZE_16M
-
 ( ROM size [$0148] )
 $00 constant ROM_SIZE_32KBYTE
+$00 constant ROM_SIZE_256KBIT
 $01 constant ROM_SIZE_64KBYTE
+$01 constant ROM_SIZE_512KBIT
 $02 constant ROM_SIZE_128KBYTE
+$02 constant ROM_SIZE_1MBIT
 $03 constant ROM_SIZE_256KBYTE
+$03 constant ROM_SIZE_2MBIT
 $04 constant ROM_SIZE_512KBYTE
+$04 constant ROM_SIZE_4MBIT
 $05 constant ROM_SIZE_1MBYTE
+$05 constant ROM_SIZE_8MBIT
 $06 constant ROM_SIZE_2MBYTE
+$06 constant ROM_SIZE_16MBIT
 $07 constant ROM_SIZE_4MBYTE
+$07 constant ROM_SIZE_32MBIT
 $08 constant ROM_SIZE_8MBYTE
-
-\ #0 constant RAM_SIZE_0KBIT
-\ #1 constant RAM_SIZE_16KBIT
-\ #2 constant RAM_SIZE_64KBIT
-\ #3 constant RAM_SIZE_256KBIT
-\ #4 constant RAM_SIZE_1MBIT
+$08 constant ROM_SIZE_64MBIT
 
 ( RAM size [$0149] )
+$00 constant RAM_SIZE_NONE
 $00 constant RAM_SIZE_0KBYTE
+$00 constant RAM_SIZE_0KBIT
 $01 constant RAM_SIZE_2KBYTE
+$01 constant RAM_SIZE_16KBIT
 $02 constant RAM_SIZE_8KBYTE
+$02 constant RAM_SIZE_64KBIT
 $03 constant RAM_SIZE_32KBYTE
+$03 constant RAM_SIZE_256KBIT
 $04 constant RAM_SIZE_128KBYTE
+$04 constant RAM_SIZE_1MBIT
 $05 constant RAM_SIZE_64KBYTE
+$03 constant RAM_SIZE_512KBIT
 
 ( Destination code [$014A] )
 $00 constant DEST_JAP

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -20,7 +20,7 @@ $01 constant ROM_MBC1
 $02 constant ROM_MBC1_RAM
 $03 constant ROM_MBC1_RAM_BAT
 $05 constant ROM_MBC2
-$06 constant ROM_MBC2_BAT
+$06 constant ROM_MBC2_RAM_BAT
 $08 constant ROM_NOMBC_RAM
 $09 constant ROM_NOMBC_RAM_BAT
 $0B constant ROM_MMM01
@@ -31,15 +31,14 @@ $10 constant ROM_MBC3_TIMER_RAM_BAT
 $11 constant ROM_MBC3
 $12 constant ROM_MBC3_RAM
 $13 constant ROM_MBC3_RAM_BAT
-$15 constant ROM_MBC4
-$16 constant ROM_MBC4_RAM
-$17 constant ROM_MBC4_RAM_BAT
 $19 constant ROM_MBC5
 $1A constant ROM_MBC5_RAM
 $1B constant ROM_MBC5_RAM_BAT
 $1C constant ROM_MBC5_RUMBLE
 $1D constant ROM_MBC5_RUMBLE_RAM
 $1E constant ROM_MBC5_RUMBLE_RAM_BAT
+$20 constant ROM_MBC6_RAM_BAT
+$22 constant ROM_MBC7_RAM_BAT_ACCELEROMETER
 $FC constant ROM_POCKET_CAMEREA
 $FD constant ROM_BANDAI_TAMA5
 $FE constant ROM_HUC3
@@ -62,9 +61,7 @@ $04 constant ROM_SIZE_512KBYTE
 $05 constant ROM_SIZE_1MBYTE
 $06 constant ROM_SIZE_2MBYTE
 $07 constant ROM_SIZE_4MBYTE
-$52 constant ROM_SIZE_1.1MBYTE
-$53 constant ROM_SIZE_1.2MBYTE
-$54 constant ROM_SIZE_1.5MBYTE
+$08 constant ROM_SIZE_8MBYTE
 
 \ #0 constant RAM_SIZE_0KBIT
 \ #1 constant RAM_SIZE_16KBIT

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -5,6 +5,14 @@ also gb-assembler
 
 ( Constants used in cartridge header )
 
+: logo
+  $ce rom, $ed rom, $66 rom, $66 rom, $cc rom, $0d rom, $00 rom, $0b rom,
+  $03 rom, $73 rom, $00 rom, $83 rom, $00 rom, $0c rom, $00 rom, $0d rom,
+  $00 rom, $08 rom, $11 rom, $1f rom, $88 rom, $89 rom, $00 rom, $0e rom,
+  $dc rom, $cc rom, $6e rom, $e6 rom, $dd rom, $dd rom, $d9 rom, $99 rom,
+  $bb rom, $bb rom, $67 rom, $63 rom, $6e rom, $0e rom, $ec rom, $cc rom,
+  $dd rom, $dc rom, $99 rom, $9f rom, $bb rom, $b9 rom, $33 rom, $3e rom, ;
+
 ( CGB flag [$0143] )
 $80 constant CGB_SUPPORTED
 $C0 constant CGB_ONLY
@@ -57,6 +65,40 @@ $02 constant RAM_SIZE_8KBYTE
 $03 constant RAM_SIZE_32KBYTE
 $04 constant RAM_SIZE_128KBYTE
 $05 constant RAM_SIZE_64KBYTE
+
+( Words to modify header values )
+
+: parse-line ( -- addr u )
+  #10 parse ;
+
+: title:
+  parse-line
+  dup #15 > abort" Title is too long"
+  $134 offset>addr swap move ;
+
+: manufacturer:
+  parse-line
+  dup #4 > abort" Manufacturer Code is too long"
+  $013F offset>addr swap move ;
+
+: licensee:
+  parse-line
+  dup #2 > abort" Licensee Code is too long"
+  $0144 offset>addr swap move
+  $33 $014B rom! ;
+
+: gbgame $00 $0143 rom! ; ( non color )
+
+
+: header-complement
+  0
+  $014D $0134 ?do
+    i rom@ +
+  loop
+  $19 + negate ;
+
+: fix-header-complement
+  header-complement $014D rom! ;
 
 ( Cartridge structure )
 

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -5,47 +5,55 @@ also gb-assembler
 
 ( Constants used in cartridge header )
 
-#0 constant ROM_NOMBC
-#1 constant ROM_MBC1
-#2 constant ROM_MBC1_RAM
-#3 constant ROM_MBC1_RAM_BAT
-#5 constant ROM_MBC2
-#6 constant ROM_MBC2_BAT
-#8 constant ROM_NOMBC_RAM
-#9 constant ROM_NOMBC_RAM_BAT
+( Cartridge type [$0147] )
+$00 constant ROM_NOMBC
+$01 constant ROM_MBC1
+$02 constant ROM_MBC1_RAM
+$03 constant ROM_MBC1_RAM_BAT
+$05 constant ROM_MBC2
+$06 constant ROM_MBC2_BAT
+$08 constant ROM_NOMBC_RAM
+$09 constant ROM_NOMBC_RAM_BAT
 
-#0 constant ROM_SIZE_256KBIT
-#1 constant ROM_SIZE_512KBIT
-#2 constant ROM_SIZE_1M
-#3 constant ROM_SIZE_2M
-#4 constant ROM_SIZE_4M
-#5 constant ROM_SIZE_8M
-#6 constant ROM_SIZE_16M
+\ #0 constant ROM_SIZE_256KBIT
+\ #1 constant ROM_SIZE_512KBIT
+\ #2 constant ROM_SIZE_1M
+\ #3 constant ROM_SIZE_2M
+\ #4 constant ROM_SIZE_4M
+\ #5 constant ROM_SIZE_8M
+\ #6 constant ROM_SIZE_16M
 
-#0 constant ROM_SIZE_32KBYTE
-#1 constant ROM_SIZE_64KBYTE
-#2 constant ROM_SIZE_128KBYTE
-#3 constant ROM_SIZE_256KBYTE
-#4 constant ROM_SIZE_512KBYTE
-#5 constant ROM_SIZE_1MBYTE
-#6 constant ROM_SIZE_2MBYTE
+( ROM size [$0148] )
+$00 constant ROM_SIZE_32KBYTE
+$01 constant ROM_SIZE_64KBYTE
+$02 constant ROM_SIZE_128KBYTE
+$03 constant ROM_SIZE_256KBYTE
+$04 constant ROM_SIZE_512KBYTE
+$05 constant ROM_SIZE_1MBYTE
+$06 constant ROM_SIZE_2MBYTE
+$07 constant ROM_SIZE_4MBYTE
+$52 constant ROM_SIZE_1.1MBYTE
+$53 constant ROM_SIZE_1.2MBYTE
+$54 constant ROM_SIZE_1.5MBYTE
 
-#0 constant RAM_SIZE_0KBIT
-#1 constant RAM_SIZE_16KBIT
-#2 constant RAM_SIZE_64KBIT
-#3 constant RAM_SIZE_256KBIT
-#4 constant RAM_SIZE_1MBIT
+\ #0 constant RAM_SIZE_0KBIT
+\ #1 constant RAM_SIZE_16KBIT
+\ #2 constant RAM_SIZE_64KBIT
+\ #3 constant RAM_SIZE_256KBIT
+\ #4 constant RAM_SIZE_1MBIT
 
-#0 constant RAM_SIZE_0KBYTE
-#1 constant RAM_SIZE_2KBYTE
-#2 constant RAM_SIZE_8KBYTE
-#3 constant RAM_SIZE_32KBYTE
-#4 constant RAM_SIZE_128KBYTE
+( RAM size [$0149] )
+$00 constant RAM_SIZE_0KBYTE
+$01 constant RAM_SIZE_2KBYTE
+$02 constant RAM_SIZE_8KBYTE
+$03 constant RAM_SIZE_32KBYTE
+$04 constant RAM_SIZE_128KBYTE
+$05 constant RAM_SIZE_64KBYTE
+
+( Cartridge structure )
 
 ( A placeholder for values)
 : $xx $42 ;
-
-( Cartridge structure )
 
 $00 ==> ( restart $00 address )
 $08 ==> ( restart $08 address )

--- a/src/rom.fs
+++ b/src/rom.fs
@@ -38,47 +38,6 @@ rom erase
 : ==> ( n -- )
   rom-offset! ;
 
-: logo
-  $ce rom, $ed rom, $66 rom, $66 rom, $cc rom, $0d rom, $00 rom, $0b rom,
-  $03 rom, $73 rom, $00 rom, $83 rom, $00 rom, $0c rom, $00 rom, $0d rom,
-  $00 rom, $08 rom, $11 rom, $1f rom, $88 rom, $89 rom, $00 rom, $0e rom,
-  $dc rom, $cc rom, $6e rom, $e6 rom, $dd rom, $dd rom, $d9 rom, $99 rom,
-  $bb rom, $bb rom, $67 rom, $63 rom, $6e rom, $0e rom, $ec rom, $cc rom,
-  $dd rom, $dc rom, $99 rom, $9f rom, $bb rom, $b9 rom, $33 rom, $3e rom, ;
-
-: parse-line ( -- addr u )
-  #10 parse ;
-
-: title:
-  parse-line
-  dup #15 > abort" Title is too long"
-  $134 offset>addr swap move ;
-
-: manufacturer:
-  parse-line
-  dup #4 > abort" Manufacturer Code is too long"
-  $013F offset>addr swap move ;
-
-: licensee:
-  parse-line
-  dup #2 > abort" Licensee Code is too long"
-  $0144 offset>addr swap move
-  $33 $014B rom! ;
-
-: gbgame $00 $0143 rom! ; ( non color )
-
-
-: header-complement
-  0
-  $014D $0134 ?do
-    i rom@ +
-  loop
-  $19 + negate ;
-
-: fix-header-complement
-  header-complement $014D rom! ;
-
-
 0 Value rom-fd
 : dump-rom ( c-addr u -- )
   w/o bin create-file throw TO rom-fd


### PR DESCRIPTION
- Removed everything specific to the hello-worlds example from `cartridge.fs` (and moved to `hello.fs`). Specifically:
    - The `title:`
    - The `reti,` instructions on top of the header
    - The global checksum bytes
- Implemented the `global-checksum` calculation and `fix-global-checksum` word.
- Moved cartridge related constants from `gbhw.fs` to `cartridge.fs` and fixed/cleaned up some incorrect ones.