### PR TITLE
Visual testing

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -3,6 +3,7 @@
 const assert = require("assert");
 const path = require("path");
 const fs = require("fs");
+const crypto = require("crypto");
 const Gameboy = require("node-gameboy");
 
 function runTest(rompath, { cycles }, cb) {
@@ -21,6 +22,30 @@ function runTest(rompath, { cycles }, cb) {
   }
 
   cb(gameboy, memory);
+}
+
+function getSha(x) {
+  const hash = crypto.createHash('sha256');
+  hash.update(x);
+  return hash.digest('hex');
+}
+
+function runVisualTest(rompath, { steps }, cb) {
+  const gameboy = new Gameboy()
+  gameboy.loadCart(fs.readFileSync(rompath));
+
+  let imgBuffer;
+  gameboy.gpu.on('frame', (canvas) => {
+    imgBuffer = canvas.toBuffer()
+  });
+
+  gameboy._init();
+  for (let i = 0; i < steps; i++) {
+    gameboy._cpu._step()
+  }
+
+  const sha = getSha(imgBuffer)
+  cb(imgBuffer, sha)
 }
 
 function depth(gameboy) {
@@ -111,3 +136,12 @@ runTest(
     assert.deepStrictEqual(stack(gameboy), [11]);
   }
 );
+
+runVisualTest(
+  path.resolve(__dirname, "../examples/hello-world-asm/hello.gb"),
+  { steps: 10 },
+  (imgBuffer, sha) => {
+    // fs.writeFileSync(`hello.png`, imgBuffer);
+    assert.equal(sha, '1dded7c5cbaaa4b94377fc76574deffb0869ee65e9b72dfafae0604304fbe365')
+  }
+)

--- a/test/test.js
+++ b/test/test.js
@@ -141,7 +141,16 @@ runVisualTest(
   path.resolve(__dirname, "../examples/hello-world-asm/hello.gb"),
   { steps: 10 },
   (imgBuffer, sha) => {
-    // fs.writeFileSync(`hello.png`, imgBuffer);
+    // fs.writeFileSync(`hello-asm.png`, imgBuffer);
+    assert.equal(sha, '1dded7c5cbaaa4b94377fc76574deffb0869ee65e9b72dfafae0604304fbe365')
+  }
+)
+
+runVisualTest(
+  path.resolve(__dirname, "../examples/hello-world/hello.gb"),
+  { steps: 10 },
+  (imgBuffer, sha) => {
+    // fs.writeFileSync(`hello-forth.png`, imgBuffer);
     assert.equal(sha, '1dded7c5cbaaa4b94377fc76574deffb0869ee65e9b72dfafae0604304fbe365')
   }
 )


### PR DESCRIPTION
Couldn't get this to work with cpu cycles (so using steps instead), but this can be used to verify the image output of a rom.

~Downside: our `hello.fs` (non-asm) seems to not render "Hello world" anymore :(~ Fixed after rebasing