### PR TITLE
Alternative to labels in asm.fs

### DIFF
--- a/etc/dmgforth.el
+++ b/etc/dmgforth.el
@@ -27,7 +27,8 @@
 
 (defvar dmgforth-keywords
   '("begin-dispatch" "end-dispatch" "~~>" "::"
-    "end-instruction" "tile" "local" "end-local"))
+    "end-instruction" "tile" "local" "end-local"
+    "begin," "while," "repeat," "until," "if," "else," "then,"))
 
 (dolist (w dmgforth-keywords)
   (forth-syntax--define w #'forth-syntax--state-font-lock-keyword))

--- a/examples/hello-world-asm/memory.fs
+++ b/examples/hello-world-asm/memory.fs
@@ -85,10 +85,10 @@ end-local
 [asm]
 
 : lcd_WaitVRAM
-  here<
+  begin,
     [rSTAT] a ld,
     STATF_BUSY # A and,
-  <there #nz jr, ;
+  #z until, ;
 
 [endasm]
 [endhost]

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -789,7 +789,7 @@ end-instruction
 
 \ if...then
 
-: if, there> swap-args jr, ;
+: if, invert-flag there> swap-args jr, ;
 : then, >here ;
 
 \ begin...while...repeat

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -327,6 +327,12 @@ false value start-defined?
 false value main-defined?
 
 [public]
+
+( Simplified label. We aim to remove label completely, then we'll
+( rename this one )
+: label'
+  offset constant ;
+
 : label
   parse-name make-label ;
 

--- a/src/primitives.fs
+++ b/src/primitives.fs
@@ -269,7 +269,6 @@ ret,
 
 code cmove ( c-from c-to u -- )
 local
-presume .end
 ( DE = c-to )
 ( BC = c-from )
 ( HL = u )
@@ -285,24 +284,14 @@ C inc, BC push,
 [C] ->A-> B ld,  C dec,
 [C] ->A-> C ld,
 
-
-( check if HL=0 )
-H|L->A,
-.end #Z jr,
-
-label .body
-
-( copy one byte )
-[BC] ->A-> [DE] ld,
-BC inc,
-DE inc,
-
-HL dec,
-
-H|L->A,
-.body #NZ jr,
-
-label .end
+begin, H|L->A, #NZ while, 
+  ( copy one byte )
+  [BC] ->A-> [DE] ld,
+  BC inc,
+  DE inc,
+  
+  HL dec,
+repeat,
 
 BC pop, C inc,
 ps-drop,


### PR DESCRIPTION
Forward-reference to labels seem too powerful and they make interop between Forth and asm harder. This pull request aims to provide an alternative approach to the current labels in asm.fs

## Stack-based references

- The words `here<` and `<there` allow for backward references in asm.
- The words `there>` and `>here` for forward references.

## Structured control flow
- Provide words similar to the ones available in Forth: 
  - `begin,` `until,`
  - `if,` `then,`

## New labels
Labels would be maintained as an ordinary constant, allowing back references.

## Future work
- Migrate all forward-reference to labels to use the new constructs. 
- Delete current labels

In the case of far forward references, the following trick can be used

```forth
there> jp, 
constant long-jump

( no need to keep the value in the stack here )

long-jump >here
```