### PR TITLE
Add named references

### DIFF
--- a/examples/hello-world-asm/hello.fs
+++ b/examples/hello-world-asm/hello.fs
@@ -23,14 +23,11 @@ a [rGBP] ld,
 a [rSCX] ld,
 a [rSCY] ld,
 
-presume StopLCD
-
-StopLCD call,
+there> call, named-ref> >StopLCD
 
 
-presume TileData
 
-TileData hl ld,
+there> hl ld, named-ref> >TileData
 _VRAM # de ld,
 [host] 256 8 * [endhost] # bc ld,
 
@@ -59,9 +56,7 @@ mem_SetVRAM call,
 : %Title s" Hello World !" ;
 [endhost]
 
-PRESUME Title
-
-Title hl ld,
+there> hl ld, named-ref> >Title
 [host] _SCRN0 3 + SCRN_VY_B 7 * + [endhost] # de ld,
 
 [host] %Title nip [endhost] # bc ld,
@@ -74,7 +69,7 @@ nop,
 wait jr,
 
 ( HACK: Don't use dmgforth internals here )
-label Title
+>Title
 [host]
 also dmgforth
 %title rom-move
@@ -83,7 +78,7 @@ previous
 
 nop,
 
-label StopLCD
+>StopLCD
 [rLCDC] A ld,
 rlca,
 
@@ -99,7 +94,7 @@ A [rLCDC] ld,
 
 ret,
 
-label TileData
+>TileData
 include ./ibm-font.fs
 
 [endasm]

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -300,6 +300,9 @@ end-types
   endcase ;
 
 : named-ref>
+  dup forward_rel_ref <> swap
+  dup forward_abs_ref <> rot
+  and abort" Expected a forward reference."
   CREATE , ,
   DOES> dup cell+ @ swap @
   >here ;
@@ -312,6 +315,7 @@ end-types
   # ;
 
 : named-ref<
+  dup backward_mark <> abort" Expected a backward reference."
   CREATE , ,
   DOES> dup cell+ @ swap @
   <there ;

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -299,12 +299,22 @@ end-types
     true abort" Expected a forward reference."
   endcase ;
 
+: named-ref>
+  CREATE , ,
+  DOES> dup cell+ @ swap @
+  >here ;
+
 : here<
   offset backward_mark ;
 
 : <there
   backward_mark <> abort" Expected a backward reference."
   # ;
+
+: named-ref<
+  CREATE , ,
+  DOES> dup cell+ @ swap @
+  <there ;
 
 : presume
   create


### PR DESCRIPTION
Adds 2 words `named-ref>` and `named-ref<` to be used in combination with `there>` and `here<`.
This removes all forward references from the asm example.

Use for long backward reference:
```forth
here<
named-ref< someName
\ code to jump to

( ... )

someName jp,
```

Use for long forward reference:
```forth
there> jp,
named-ref> someName

( ... )

someName
\ code to jump to