### PR TITLE
Move prelude below input-file

### DIFF
--- a/dmgforth
+++ b/dmgforth
@@ -48,7 +48,7 @@ require ./src/user.fs
 
 also gb-assembler-impl
 : assert-main-defined
-  main-defined? invert abort" Entry point (main) is not defined" ;
+  main-addr @ -1 = abort" Entry point (main) is not defined" ;
 previous
 
 : write-game-and-die
@@ -65,13 +65,16 @@ previous
 
   --no-kernel invert if
     s" core.fs" required
-  
-    __start:
-    ps-init,
-    main jp,
   then
 
   input-file included
+
+  --no-kernel invert if
+    begin, halt, repeat,
+    __start:
+    ps-init,
+    main-addr @ # jp,
+  then
 
   --no-kernel invert if
     assert-main-defined

--- a/src/asm.fs
+++ b/src/asm.fs
@@ -343,13 +343,12 @@ end-types
     nextname label
   then ;
 
-false value main-defined?
-
 [public]
+variable main-addr
+-1 main-addr !
 
 : main:
-  s" main" make-label
-  true is main-defined? ;
+  offset main-addr ! ;
 [endpublic]
 
 ( Arguments pattern matching )

--- a/src/cartridge.fs
+++ b/src/cartridge.fs
@@ -166,11 +166,6 @@ $0078 ==> reti, ( high-to-low of p13 interrupt start address )
 
 $0100 ==> ( start entry point [$0100-$0103] )
 
-( TODO: Remove forward label / presume )
-also gb-assembler-impl
-presume main
-previous
-
 nop,
 there> jp,
 named-ref> __start:

--- a/src/user.fs
+++ b/src/user.fs
@@ -38,7 +38,6 @@ export [asm]
 export [endasm]
 
 export __start:
-export main
 export main:
 
 export title:


### PR DESCRIPTION
Moves the initialisation code (`__start:`) below the code generated by the input-file. This fixes the issue described in #50, where we want to emit an address (the DP) that is updated by the input-file.